### PR TITLE
fixed error count reset bug

### DIFF
--- a/src/urg_node2.cpp
+++ b/src/urg_node2.cpp
@@ -499,6 +499,7 @@ void UrgNode2::scan_thread()
           RCLCPP_WARN(get_logger(), "Could not get single echo scan.");
           error_count_++;
           total_error_count_++;
+          prev_time = system_clock.now();
           device_status_ = urg_sensor_status(&urg_);
           sensor_status_ = urg_sensor_state(&urg_);
           is_stable_ = urg_is_stable(&urg_);
@@ -514,10 +515,8 @@ void UrgNode2::scan_thread()
         break;
       } else {
         // エラーカウントのリセット
-        rclcpp::Time current_time = system_clock.now();
-        rclcpp::Duration period = current_time - prev_time;
+        rclcpp::Duration period = system_clock.now() - prev_time;
         if (period.seconds() >= error_reset_period_) {
-          prev_time = current_time;
           error_count_ = 0;
         }
       }


### PR DESCRIPTION
[JIRA Link](https://dexory.atlassian.net/browse/AUTO-594)

See my more detailed notes in the JIRA issue. This PR fixes a bug in the urg_node driver that causes the error_counts to be contentiously reset so the driver never detected that it has been disconnected. This PR fixes the issue and has been tested on the bench.