### PR TITLE
Error counts continuously being reset

### DIFF
--- a/src/urg_node2.cpp
+++ b/src/urg_node2.cpp
@@ -484,6 +484,7 @@ void UrgNode2::scan_thread()
           RCLCPP_WARN(get_logger(), "Could not get multi echo scan.");
           error_count_++;
           total_error_count_++;
+          prev_time = system_clock.now();
           device_status_ = urg_sensor_status(&urg_);
           sensor_status_ = urg_sensor_state(&urg_);
           is_stable_ = urg_is_stable(&urg_);

--- a/src/urg_node2.cpp
+++ b/src/urg_node2.cpp
@@ -499,6 +499,7 @@ void UrgNode2::scan_thread()
           RCLCPP_WARN(get_logger(), "Could not get single echo scan.");
           error_count_++;
           total_error_count_++;
+          prev_time = system_clock.now();
           device_status_ = urg_sensor_status(&urg_);
           sensor_status_ = urg_sensor_state(&urg_);
           is_stable_ = urg_is_stable(&urg_);
@@ -514,10 +515,8 @@ void UrgNode2::scan_thread()
         break;
       } else {
         // エラーカウントのリセット
-        rclcpp::Time current_time = system_clock.now();
-        rclcpp::Duration period = current_time - prev_time;
+        rclcpp::Duration period = system_clock.now() - prev_time;
         if (period.seconds() >= error_reset_period_) {
-          prev_time = current_time;
           error_count_ = 0;
         }
       }


### PR DESCRIPTION
Hello,

We've been using the urg_node2 on our robots with the UAM-05LP scanner. Our robots are using ROS Humble. The problem we experienced was when the laser was disconnected/powered down temporarily. The driver gets stuck in a loop where the error_count_ never reaches the error_limit_ because when an error occurs the driver is updating the diagnostic status:

https://github.com/Hokuyo-aut/urg_node2/blob/6632d1ce1859a2ad8ad11d1c1b1117178769f263/src/urg_node2.cpp#L498-L505

Which can take ~1-2 seconds each time. This is causing the error_counts to be reset before they reach the limit because of this block: 

https://github.com/Hokuyo-aut/urg_node2/blob/6632d1ce1859a2ad8ad11d1c1b1117178769f263/src/urg_node2.cpp#L517-L522

Semantically the purpose of the above block seems to be to reset the error counts if we haven't seen an error in a while but what's actually happening is the error counts are always being reset after the **error_reset_period**.

See the log from below (with an added log statement every time the error counts are reset).
![image-20230221-225013](https://user-images.githubusercontent.com/2834094/221147752-7c2c64a4-7119-422c-b3aa-92ebf4eac54f.png)

This PR moves the setting of prev_time to error block. This fixes the error reset count loop and has been tested with our UAM's and works well. I've added it to the multi-echo branch but don't have a multi-echo scanner to test, given they are identical blocks it should work the same. 
