### PR TITLE
Intensity data not being published fix

### DIFF
--- a/src/urg_node2.cpp
+++ b/src/urg_node2.cpp
@@ -294,7 +294,22 @@ bool UrgNode2::connect()
 
   // 接続先のLiDARが強度出力に対応しているか
   if (publish_intensity_) {
-    use_intensity_ = is_intensity_supported();
+    error_count_ = 0;
+    while (rclcpp::ok()) {
+      RCLCPP_INFO(get_logger(), "Trying to init intensity mode");
+      if (is_intensity_supported()) {
+        RCLCPP_INFO(get_logger(), "Intensity mode init success");
+        use_intensity_ = true;
+        break;
+      }
+      RCLCPP_WARN(get_logger(), "Failed to init intensity mode");
+      error_count_ += 1;
+      if (error_count_ > error_limit_) {
+        error_count_ = 0;
+        use_intensity_ = false;
+        break;
+      }
+    }
     if (!use_intensity_) {
       RCLCPP_WARN(
         get_logger(),
@@ -303,7 +318,22 @@ bool UrgNode2::connect()
   }
   // 接続先のLiDARがマルチエコー出力に対応しているか
   if (publish_multiecho_) {
-    use_multiecho_ = is_multiecho_supported();
+    error_count_ = 0;
+    while (rclcpp::ok()) {
+      RCLCPP_INFO(get_logger(), "Trying to init multiecho mode");
+      if (is_multiecho_supported()) {
+        RCLCPP_INFO(get_logger(), "Multiecho mode init success");
+        use_multiecho_ = true;
+        break;
+      }
+      RCLCPP_WARN(get_logger(), "Failed to init multiecho mode");
+      error_count_ += 1;
+      if (error_count_ > error_limit_) {
+        error_count_ = 0;
+        use_multiecho_ = false;
+        break;
+      }
+    }
     if (!use_multiecho_) {
       RCLCPP_WARN(
         get_logger(),
@@ -396,6 +426,8 @@ void UrgNode2::disconnect()
     urg_close(&urg_);
     is_connected_ = false;
   }
+  if (is_measurement_started_)
+		is_measurement_started_ = false;
 }
 
 // Lidarとの再接続処理
@@ -782,6 +814,8 @@ bool UrgNode2::is_intensity_supported(void)
   int ret = urg_get_distance_intensity(&urg_, &distance_[0], &intensity_[0], NULL);
   if (ret <= 0) {
     // 強度出力非対応
+    urg_stop_measurement(&urg_);
+    is_measurement_started_ = false;
     return false;
   }
 
@@ -806,6 +840,8 @@ bool UrgNode2::is_multiecho_supported(void)
   int ret = urg_get_multiecho(&urg_, &distance_[0], NULL);
   if (ret <= 0) {
     // マルチエコー出力非対応
+    urg_stop_measurement(&urg_);
+    is_measurement_started_ = false;
     return false;
   }
 


### PR DESCRIPTION
This PR fixes an issue we've had with the reliability of publishing intensity data. The problem is the is_intensity_supported() function. We've had a few different cases where this function fails for sensors that **do** support intensity data:

- If the sensor is reconnecting is_measurement_started_ can sometimes already be set to true so the intensity check won't even be attempted
- The actual urg_get_distance_intensity can sometimes fail (due to network issues etc) 

As the driver only tries this test once it's possible for you to end up with no intensity data being published on a sensor that does support it. We're using the intensity data for mission critical functions on our robot so it's really important it's always present. 

I've added this fix which will retry the is_intensity_supported() check a few times (using the error_count and error_limit so it does a fixed number of attempts). We've found this a reliable method to ensure we always have intensity data from our sensors. 